### PR TITLE
examples: fix running the example from an arbitrary working folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Ensure all examples compile
         run: cd xlsx && v should-compile-all examples/
+
+      - name: Ensure marks example, can run from an arbitrary working folder
+        run: xlsx/examples/01_marksheet/marks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           path: xlsx
 
       - name: Build V
-        run: cd v && make && ./v symlink -githubci && git clone ../xlsx/ ~/.vmodules/xlsx
+        run: |
+          cd v && make
+          ./v symlink -githubci && git clone ../xlsx/ ~/.vmodules/xlsx
 
       - name: Run tests
         run: cd xlsx && v test .
@@ -43,3 +45,6 @@ jobs:
 
       - name: Ensure documentation is OK
         run: cd xlsx && v check-md .
+
+      - name: Ensure all examples compile
+        run: cd xlsx && v should-compile-all examples/

--- a/examples/01_marksheet/marks.v
+++ b/examples/01_marksheet/marks.v
@@ -2,7 +2,7 @@ import os
 import xlsx
 
 fn main() {
-	workbook := xlsx.Document.from_file(os.resource_abs_path('01_marksheet/data.xlsx'))!
+	workbook := xlsx.Document.from_file(os.resource_abs_path('data.xlsx'))!
 	println('[info] Successfully loaded workbook with ${workbook.sheets.len} worksheets.')
 
 	println('\nAvailable sheets:')


### PR DESCRIPTION
- make example runnable from any working folder
- ci: add task to compile the examples
- ci: add task to run the marks example
